### PR TITLE
Use the remote addr in UDP reply header

### DIFF
--- a/udp-handler.go
+++ b/udp-handler.go
@@ -166,7 +166,7 @@ func (s *Server) UDPTransport(relayConn *net.UDPConn, clientAddr *net.UDPAddr, b
 				}
 				continue
 			}
-			dataBuf := AssembleHeader(b[:n], v.clientAddr)
+			dataBuf := AssembleHeader(b[:n], v.remoteAddr)
 			relayConn.WriteMsgUDP(dataBuf.Bytes(), nil, v.clientAddr)
 			log.Printf("[UDP]remote:%v send %v bytes -> client:%v\n", v.remoteAddr, n, v.clientAddr)
 		}


### PR DESCRIPTION
Hi, thanks for sharing socks5-go!

I'm working on a project that uses socks5 UDP associate and noticed a problem with socks5-go.  When it sends a UDP reply to a client, it inserts the client's address into the socks reply header instead of the remote address.

This is just a one-line fix for that problem.  Thanks!